### PR TITLE
Android支持非固定3个的initShare配置

### DIFF
--- a/android/src/main/java/com/zzy/umshare/UMShareModule.java
+++ b/android/src/main/java/com/zzy/umshare/UMShareModule.java
@@ -234,7 +234,7 @@ public class UMShareModule extends ReactContextBaseJavaModule implements Activit
         UMShareAPI.get(mContext).setShareConfig(config);
 
         ReadableMapKeySetIterator readableMapKeySetIterator = sharePlatforms.keySetIterator();
-        String[] keys = new String[3];
+        String[] keys = new String[sharePlatforms.toHashMap().size()];
         int i = 0;
         while (readableMapKeySetIterator.hasNextKey()) {
             String key = readableMapKeySetIterator.nextKey();


### PR DESCRIPTION
Before:
```
UMShare.initShare('appkey', {
    '1_weixin': {
        appKey: '',
        appSecret: '',
        redirectURL: ''
    },
    '2_qq': {
        appKey: '',
        appSecret: '',
        redirectURL: ''
    },
    '3_sian': {
        appKey: '',
        appSecret: '',
        redirectURL: ''
    }
}, false);
```
now: 

```
UMShare.initShare('appkey', {
    '1_weixin': {
        appKey: '',
        appSecret: '',
        redirectURL: ''
    },
    '2_qq': {
        appKey: '',
        appSecret: '',
        redirectURL: ''
    },
    '3_sian': {
        appKey: '',
        appSecret: '',
        redirectURL: ''
    }
}, false);

// or

UMShare.initShare('appkey', {
    '1_weixin': {
        appKey: '',
        appSecret: '',
        redirectURL: ''
    },
    '2_qq': {
        appKey: '',
        appSecret: '',
        redirectURL: ''
    }
}, false);

// or

UMShare.initShare('appkey', {
    '1_weixin': {
        appKey: '',
        appSecret: '',
        redirectURL: ''
    }
}, false);
```